### PR TITLE
Catch malformed data field

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -104,7 +104,13 @@ export function handleNewHash(event: NewHash): void {
       }
     } else if (transaction.isSet("data")) {
       let data = transaction.getEntry("data")!.value;
-      entity.data = data.toString();
+        try {
+          entity.data = data.toString();
+        }
+        catch (e) {
+          log.warning("IPFS document {} has a invalid data field", [ipfsHash]);
+          return;
+        }
     } else {
       log.warning(
         "IPFS document {} has a neither data or encryptedData field",


### PR DESCRIPTION
# Problem

Storage Subgraph doesn't handle malformed data in IPFS.

# Solution

Add a try/catch so that malformed data is ignored.

# Context

See [Internal Slack discussion](https://request-network-fdn.slack.com/archives/C05ANTF63GR/p1691523284524469)