### PR TITLE
chore: update deprecated commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker-compose up -d
 - Create the subgraph. Do this only once (or each time you clear the Graph node)
 
 ```
-yarn create-local ./subgraph-private.yaml
+yarn create-local
 ```
 
 - Generate types for the subgraph. Do this again if you modify the [indexer's code](./src/mapping.ts) or the [graphql schema](./schema.graphql)

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "graph build",
     "test": "graph test",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ RequestNetwork/request-storage",
-    "create-local": "graph create --node http://localhost:8020/ RequestNetwork/request-storage --access-token ''",
-    "remove-local": "graph remove --node http://localhost:8020/ RequestNetwork/request-storage --access-token ''",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 RequestNetwork/request-storage --access-token ''",
+    "create-local": "graph create --node http://localhost:8020/ RequestNetwork/request-storage",
+    "remove-local": "graph remove --node http://localhost:8020/ RequestNetwork/request-storage",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 RequestNetwork/request-storage",
     "monitor-deployment-local": "ts-node cli/monitor.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Fix the documentation an remove deprecated arguments after the update of `@graphprotocol/graph-cli` in https://github.com/RequestNetwork/storage-subgraph/pull/4

Related to: https://github.com/RequestNetwork/requestNetwork/pull/1135