### PR TITLE
chore: improve logging by including tx id and block timestamp

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -8,18 +8,18 @@ import { computeHash, serializeTransaction } from "./hash-utils";
 export function handleNewHash(event: NewHash): void {
   let ipfsHash = event.params.hash;
   let transactionId = event.transaction.hash.toHex();
-  let blockTimestamp = event.block.timestamp.toI32();
+  let blockTimestampString = event.block.timestamp.toString()
 
   log.info(
     "Retrieving and parsing IPFS hash {}, transaction ID {}, timestamp {}",
-    [ipfsHash, transactionId, blockTimestamp],
+    [ipfsHash, transactionId, blockTimestampString],
   );
 
   let data = ipfs.cat(ipfsHash);
   if (!data) {
     log.warning(
       "Could not retrieve IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestamp],
+      [ipfsHash, transactionId, blockTimestampString],
     );
     return;
   }
@@ -28,7 +28,7 @@ export function handleNewHash(event: NewHash): void {
   if (!jsonValue.isOk) {
     log.warning(
       "Parsing failed for IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestamp],
+      [ipfsHash, transactionId, blockTimestampString],
     );
     return;
   }
@@ -36,20 +36,21 @@ export function handleNewHash(event: NewHash): void {
   if (jsonValue.value.kind !== JSONValueKind.OBJECT) {
     log.warning(
       "Invalid JSON in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestamp],
+      [ipfsHash, transactionId, blockTimestampString],
     );
     return;
   }
 
   let doc = jsonValue.value.toObject();
   let blockNumber = event.block.number.toI32();
+  let blockTimestamp = event.block.timestamp.toI32();
   let address = event.address;
   let feesParameters = event.params.feesParameters;
 
   if (!doc.isSet("header") || !doc.isSet("transactions")) {
     log.warning(
       "No header or transactions field in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestamp],
+      [ipfsHash, transactionId, blockTimestampString],
     );
     return;
   }
@@ -58,7 +59,7 @@ export function handleNewHash(event: NewHash): void {
   if (!header.isSet("channelIds") || !header.isSet("topics")) {
     log.warning(
       "No header.channelIds or header.topics in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestamp],
+      [ipfsHash, transactionId, blockTimestampString],
     );
     return;
   }
@@ -71,7 +72,7 @@ export function handleNewHash(event: NewHash): void {
     let index = channelIds[txIndex].value.toArray()[0].toBigInt().toI32();
     log.info(
       "Parsing channelId {} for IPFS hash {} from transaction ID {}, timestamp {}",
-      [channelId, ipfsHash, transactionId, blockTimestamp],
+      [channelId, ipfsHash, transactionId, blockTimestampString],
     );
     let entityId = ipfsHash + "-" + index.toString();
     let entity = new Transaction(entityId);
@@ -135,7 +136,7 @@ export function handleNewHash(event: NewHash): void {
       if (data.kind !== JSONValueKind.STRING) {
         log.warning(
           "Invalid data field in IPFS hash {} from transaction ID {}, timestamp {}",
-          [ipfsHash, transactionId, blockTimestamp],
+          [ipfsHash, transactionId, blockTimestampString],
         );
         return;
       }
@@ -143,7 +144,7 @@ export function handleNewHash(event: NewHash): void {
     } else {
       log.warning(
         "Neither data or encryptedData found in IPFS hash {} from transaction ID {}, timestamp {}",
-        [ipfsHash, transactionId, blockTimestamp],
+        [ipfsHash, transactionId, blockTimestampString],
       );
     }
     entity.dataHash = computeHash(serializeTransaction(entity));

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -8,18 +8,18 @@ import { computeHash, serializeTransaction } from "./hash-utils";
 export function handleNewHash(event: NewHash): void {
   let ipfsHash = event.params.hash;
   let transactionId = event.transaction.hash.toHex();
-  let blockTimestampString = event.block.timestamp.toString();
+  let blockNumberString = event.block.number.toString();
 
   log.info(
-    "Retrieving and parsing IPFS hash {}, transaction ID {}, timestamp {}",
-    [ipfsHash, transactionId, blockTimestampString],
+    "Retrieving and parsing IPFS hash {}, transaction ID {}, block {}",
+    [ipfsHash, transactionId, blockNumberString],
   );
 
   let data = ipfs.cat(ipfsHash);
   if (!data) {
     log.warning(
-      "Could not retrieve IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestampString],
+      "Could not retrieve IPFS hash {} from transaction ID {}, block {}",
+      [ipfsHash, transactionId, blockNumberString],
     );
     return;
   }
@@ -27,16 +27,16 @@ export function handleNewHash(event: NewHash): void {
 
   if (!jsonValue.isOk) {
     log.warning(
-      "Parsing failed for IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestampString],
+      "Parsing failed for IPFS hash {} from transaction ID {}, block {}",
+      [ipfsHash, transactionId, blockNumberString],
     );
     return;
   }
 
   if (jsonValue.value.kind !== JSONValueKind.OBJECT) {
     log.warning(
-      "Invalid JSON in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestampString],
+      "Invalid JSON in IPFS hash {} from transaction ID {}, block {}",
+      [ipfsHash, transactionId, blockNumberString],
     );
     return;
   }
@@ -49,8 +49,8 @@ export function handleNewHash(event: NewHash): void {
 
   if (!doc.isSet("header") || !doc.isSet("transactions")) {
     log.warning(
-      "No header or transactions field in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestampString],
+      "No header or transactions field in IPFS hash {} from transaction ID {}, block {}",
+      [ipfsHash, transactionId, blockNumberString],
     );
     return;
   }
@@ -58,8 +58,8 @@ export function handleNewHash(event: NewHash): void {
   let header = doc.get("header")!.toObject();
   if (!header.isSet("channelIds") || !header.isSet("topics")) {
     log.warning(
-      "No header.channelIds or header.topics in IPFS hash {} from transaction ID {}, timestamp {}",
-      [ipfsHash, transactionId, blockTimestampString],
+      "No header.channelIds or header.topics in IPFS hash {} from transaction ID {}, block {}",
+      [ipfsHash, transactionId, blockNumberString],
     );
     return;
   }
@@ -71,8 +71,8 @@ export function handleNewHash(event: NewHash): void {
     let channelId = channelIds[txIndex].key;
     let index = channelIds[txIndex].value.toArray()[0].toBigInt().toI32();
     log.info(
-      "Parsing channelId {} for IPFS hash {} from transaction ID {}, timestamp {}",
-      [channelId, ipfsHash, transactionId, blockTimestampString],
+      "Parsing channelId {} for IPFS hash {} from transaction ID {}, block {}",
+      [channelId, ipfsHash, transactionId, blockNumberString],
     );
     let entityId = ipfsHash + "-" + index.toString();
     let entity = new Transaction(entityId);
@@ -135,16 +135,16 @@ export function handleNewHash(event: NewHash): void {
       let data = transaction.getEntry("data")!.value;
       if (data.kind !== JSONValueKind.STRING) {
         log.warning(
-          "Invalid data field in IPFS hash {} from transaction ID {}, timestamp {}",
-          [ipfsHash, transactionId, blockTimestampString],
+          "Invalid data field in IPFS hash {} from transaction ID {}, block {}",
+          [ipfsHash, transactionId, blockNumberString],
         );
         return;
       }
       entity.data = data.toString();
     } else {
       log.warning(
-        "Neither data or encryptedData found in IPFS hash {} from transaction ID {}, timestamp {}",
-        [ipfsHash, transactionId, blockTimestampString],
+        "Neither data or encryptedData found in IPFS hash {} from transaction ID {}, block {}",
+        [ipfsHash, transactionId, blockNumberString],
       );
     }
     entity.dataHash = computeHash(serializeTransaction(entity));

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -8,7 +8,7 @@ import { computeHash, serializeTransaction } from "./hash-utils";
 export function handleNewHash(event: NewHash): void {
   let ipfsHash = event.params.hash;
   let transactionId = event.transaction.hash.toHex();
-  let blockTimestampString = event.block.timestamp.toString()
+  let blockTimestampString = event.block.timestamp.toString();
 
   log.info(
     "Retrieving and parsing IPFS hash {}, transaction ID {}, timestamp {}",

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -10,10 +10,11 @@ export function handleNewHash(event: NewHash): void {
   let transactionId = event.transaction.hash.toHex();
   let blockNumberString = event.block.number.toString();
 
-  log.info(
-    "Retrieving and parsing IPFS hash {}, transaction ID {}, block {}",
-    [ipfsHash, transactionId, blockNumberString],
-  );
+  log.info("Retrieving and parsing IPFS hash {}, transaction ID {}, block {}", [
+    ipfsHash,
+    transactionId,
+    blockNumberString,
+  ]);
 
   let data = ipfs.cat(ipfsHash);
   if (!data) {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -7,45 +7,59 @@ import { computeHash, serializeTransaction } from "./hash-utils";
  */
 export function handleNewHash(event: NewHash): void {
   let ipfsHash = event.params.hash;
+  let transactionId = event.transaction.hash.toHex();
+  let blockTimestamp = event.block.timestamp.toI32();
 
-  log.info("Handling doc {}", [ipfsHash]);
+  log.info(
+    "Retrieving and parsing IPFS hash {}, transaction ID {}, timestamp {}",
+    [ipfsHash, transactionId, blockTimestamp],
+  );
 
   let data = ipfs.cat(ipfsHash);
   if (!data) {
-    log.warning("Could not retrieve IPFS hash {}", [ipfsHash]);
+    log.warning(
+      "Could not retrieve IPFS hash {} from transaction ID {}, timestamp {}",
+      [ipfsHash, transactionId, blockTimestamp],
+    );
     return;
   }
   let jsonValue = json.try_fromBytes(data as Bytes);
 
   if (!jsonValue.isOk) {
-    log.warning("Parsing failed for IPFS document {}", [ipfsHash]);
+    log.warning(
+      "Parsing failed for IPFS hash {} from transaction ID {}, timestamp {}",
+      [ipfsHash, transactionId, blockTimestamp],
+    );
     return;
   }
 
   if (jsonValue.value.kind !== JSONValueKind.OBJECT) {
-    log.warning("IPFS document is not a valid json", [ipfsHash]);
+    log.warning(
+      "Invalid JSON in IPFS hash {} from transaction ID {}, timestamp {}",
+      [ipfsHash, transactionId, blockTimestamp],
+    );
     return;
   }
 
   let doc = jsonValue.value.toObject();
   let blockNumber = event.block.number.toI32();
-  let blockTimestamp = event.block.timestamp.toI32();
   let address = event.address;
-  let txHash = event.transaction.hash;
   let feesParameters = event.params.feesParameters;
 
   if (!doc.isSet("header") || !doc.isSet("transactions")) {
-    log.warning("IPFS document {} has a no header or transactions field", [
-      ipfsHash,
-    ]);
+    log.warning(
+      "No header or transactions field in IPFS hash {} from transaction ID {}, timestamp {}",
+      [ipfsHash, transactionId, blockTimestamp],
+    );
     return;
   }
 
   let header = doc.get("header")!.toObject();
   if (!header.isSet("channelIds") || !header.isSet("topics")) {
-    log.warning("IPFS document {} has no header.channelIds or header.topics", [
-      ipfsHash,
-    ]);
+    log.warning(
+      "No header.channelIds or header.topics in IPFS hash {} from transaction ID {}, timestamp {}",
+      [ipfsHash, transactionId, blockTimestamp],
+    );
     return;
   }
   let channelIds = header.get("channelIds")!.toObject().entries;
@@ -55,7 +69,10 @@ export function handleNewHash(event: NewHash): void {
   for (let txIndex = 0; txIndex < channelIds.length; ++txIndex) {
     let channelId = channelIds[txIndex].key;
     let index = channelIds[txIndex].value.toArray()[0].toBigInt().toI32();
-    log.info("parsing channelId {} for ipfsId {}", [channelId, ipfsHash]);
+    log.info(
+      "Parsing channelId {} for IPFS hash {} from transaction ID {}, timestamp {}",
+      [channelId, ipfsHash, transactionId, blockTimestamp],
+    );
     let entityId = ipfsHash + "-" + index.toString();
     let entity = new Transaction(entityId);
     let channel = Channel.load(channelId);
@@ -87,7 +104,7 @@ export function handleNewHash(event: NewHash): void {
     entity.blockNumber = blockNumber;
     entity.blockTimestamp = blockTimestamp;
     entity.smartContractAddress = address.toHex();
-    entity.transactionHash = txHash.toHex();
+    entity.transactionHash = transactionId;
     entity.topics = topicList;
     entity.size = feesParameters.toHex();
 
@@ -116,14 +133,17 @@ export function handleNewHash(event: NewHash): void {
     } else if (transaction.isSet("data")) {
       let data = transaction.getEntry("data")!.value;
       if (data.kind !== JSONValueKind.STRING) {
-        log.warning("IPFS document {} has a invalid data field", [ipfsHash]);
+        log.warning(
+          "Invalid data field in IPFS hash {} from transaction ID {}, timestamp {}",
+          [ipfsHash, transactionId, blockTimestamp],
+        );
         return;
       }
       entity.data = data.toString();
     } else {
       log.warning(
-        "IPFS document {} has a neither data or encryptedData field",
-        [ipfsHash],
+        "Neither data or encryptedData found in IPFS hash {} from transaction ID {}, timestamp {}",
+        [ipfsHash, transactionId, blockTimestamp],
       );
     }
     entity.dataHash = computeHash(serializeTransaction(entity));


### PR DESCRIPTION
# Changes

* chore: improve logging by including tx id and block timestamp

# Motivation

Logs for a single mapping IPFS CID are split across multiple log statements and are sometimes interleaved with unrelated log messages. Adding the transaction ID and block timestamp makes log analysis much easier.

Before this change, logs from processing an IPFS CID looked like this:

```
Jul  6 04:06:02 stage gnosis_graph-node.1.n4kqi1g5ye2juyv5rl41xuy8k[627]: Jul 06 04:06:02.269 INFO Handling doc QmcB8HUTaCvDgs9xEHukHXS1os5AQzuydqifwUyJgPxckG, data_source: Contract, sgd: 1, subgraph_id: QmfEQz7jvpEzM5cLvsmPJJXB97LGvNG8TBJf8PvUxxPuKE, component: SubgraphInstanceManager > UserMapping
Jul  6 04:06:02 stage gnosis_graph-node.1.n4kqi1g5ye2juyv5rl41xuy8k[627]: Jul 06 04:06:02.272 INFO parsing channelId 01673d1545af2e6b2598d5d51b96374b51639488e157197bb17befec86dce2ccb2 for ipfsId QmcB8HUTaCvDgs9xEHukHXS1os5AQzuydqifwUyJgPxckG, data_source: Contract, sgd: 1, subgraph_id: QmfEQz7jvpEzM5cLvsmPJJXB97LGvNG8TBJf8PvUxxPuKE, component: SubgraphInstanceManager > UserMapping
Jul  6 04:06:02 stage gnosis_graph-node.1.n4kqi1g5ye2juyv5rl41xuy8k[627]: Jul 06 04:06:02.273 INFO Done processing trigger, gas_used: 638227284, data_source: Contract, handler: handleNewHash, total_ms: 4, transaction: 0xd542…4652, address: 0x2256…b90b, signature: NewHash(string,address,bytes), sgd: 1, subgraph_id: QmfEQz7jvpEzM5cLvsmPJJXB97LGvNG8TBJf8PvUxxPuKE, component: SubgraphInstanceManager
Jul  6 04:06:02 stage gnosis_graph-node.1.n4kqi1g5ye2juyv5rl41xuy8k[627]: Jul 06 04:06:02.276 INFO Applying 3 entity operation(s), block_hash: 0xb07fb8429b91c939c0654e50655d4c8ccc0cab5b5aff6156e5a8a4ca8c4138a0, block_number: 33509546, sgd: 1, subgraph_id: QmfEQz7jvpEzM5cLvsmPJJXB97LGvNG8TBJf8PvUxxPuKE, component: SubgraphInstanceManager
```

# Context

Changes implemented while investigating https://github.com/RequestNetwork/private-issues/issues/94